### PR TITLE
feat: remove the variable `docker_centos_nonroot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,24 @@ ansible role to install Docker CE on CentOS
 
 https://galaxy.ansible.com/suzuki-shunsuke/docker-ce-centos/
 
-Requirements
-------------
+## Requirements
 
 Nothing.
 
-Role Variables
---------------
+## Role Variables
 
-* docker_centos_version: docker version. The default is latest.
-* docker_centos_started: whether docker daemon is started. The default is "no".
-* docker_centos_enabled: whether docker daemon is enabled. The default is "no".
-* docker_centos_users: users added to docker group. The default is "[]".
+name | required | default | example | description
+--- | --- | --- | --- | ---
+docker_centos_version | no | latest | 17.03.1.ce-1.el7.centos | docker version
+docker_centos_started | no | do nothing | | whether docker daemon is started
+docker_centos_enabled | no | do nothing | | whether docker daemon is enabled
+docker_centos_users | no | [] | ["vagrant"] | users added to docker group
 
-Dependencies
-------------
+## Dependencies
 
 Nothing.
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: servers
@@ -34,9 +32,9 @@ Example Playbook
     docker_centos_enabled: yes
     docker_centos_users:
     - vagrant
+    become: yes
 ```
 
-License
--------
+## License
 
-MIT
+[MIT](LICENSE)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,38 +11,31 @@
   - container-selinux
   - docker-selinux
   - docker-engine
-  become: "{{docker_centos_nonroot}}"
 - name: Install yum-utils
   yum:
     name: yum-utils
     update_cache: yes
-  become: "{{docker_centos_nonroot}}"
 - name: Add repository
   get_url:
     url: https://download.docker.com/linux/centos/docker-ce.repo
     dest: /etc/yum.repos.d/docker-ce.repo
-  become: "{{docker_centos_nonroot}}"
 - name: Install docker
   yum:
     name: docker-ce{{ (docker_centos_version == 'latest') | ternary('', '-{}'.format(docker_centos_version))}}
     update_cache: yes
-  become: "{{docker_centos_nonroot}}"
 - name: start docker daemon
   service:
     name: docker
     state: started
-  become: "{{docker_centos_nonroot}}"
   when: docker_centos_started
 - name: enable docker daemon
   service:
     name: docker
     enabled: yes
-  become: "{{docker_centos_nonroot}}"
   when: docker_centos_enabled
 - name: Add users to the docker group
   user:
     name: "{{item}}"
     groups: docker
     append: yes
-  become: "{{docker_centos_nonroot}}"
   with_items: "{{docker_centos_users}}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,6 +7,7 @@
     docker_centos_version: 17.03.1.ce-1.el7.centos
     docker_centos_users:
     - vagrant
+    become: yes
   tasks:
   - name: Check docker version
     command: docker --version

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,0 @@
----
-# vars file for docker-ce-centos
-docker_centos_nonroot: "{{ (ansible_env.HOME == '/root') | ternary('no', 'yes') }}"


### PR DESCRIPTION
BREAKING CHANGE: `become: yes` is required unless the remote user is root