### PR TITLE
feat: change ansible_centos_started variable to ansible_centos_state

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Nothing.
 name | required | default | example | description
 --- | --- | --- | --- | ---
 docker_centos_version | no | latest | | docker version
-docker_centos_started | no | do nothing | | whether docker daemon is started
-docker_centos_enabled | no | do nothing | | whether docker daemon is enabled
+docker_centos_state | no | undefined (do nothing) | "started" or "stopped" or "restarted" or "reloaded" | docker daemon state
+docker_centos_enabled | no | undefined(do nothing) | | whether docker daemon is enabled
 docker_centos_users | no | [] | ["vagrant"] | users added to docker group
 
 ## Dependencies
@@ -27,7 +27,7 @@ Nothing.
 - hosts: servers
   roles:
   - role: suzuki-shunsuke.docker-ce-centos
-    docker_centos_started: yes
+    docker_centos_state: started
     docker_centos_enabled: yes
     docker_centos_users:
     - vagrant

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,16 +9,16 @@
 - include: install_docker.yml
   when: result.rc
   static: no
-- name: start docker daemon
+- name: change the status of the docker daemon
   service:
     name: docker
-    state: started
-  when: docker_centos_started
-- name: enable docker daemon
+    state: "{{docker_centos_state}}"
+  when: docker_centos_state is not undefined
+- name: make docker daemon enabled or disabled
   service:
     name: docker
-    enabled: yes
-  when: docker_centos_enabled
+    enabled: "{{docker_centos_enabled}}"
+  when: docker_centos_enabled is not undefined
 - name: add users to the docker group
   user:
     name: "{{item}}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,7 +2,7 @@
 - hosts: default
   roles:
   - role: ansible-docker-ce-centos
-    docker_centos_started: yes
+    docker_centos_state: started
     docker_centos_enabled: yes
     docker_centos_users:
     - vagrant


### PR DESCRIPTION
BREAKING_CHANGE: ansible_centos_started variable has been removed.
Change `ansible_centos_started: yes` to `ansible_centos_state: started`