### PR TITLE
fix: fix deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ansible-docker-ce-centos
 
+[![GitHub last commit](https://img.shields.io/github/last-commit/suzuki-shunsuke/ansible-docker-ce-centos.svg)](https://github.com/suzuki-shunsuke/ansible-docker-ce-centos)
+[![GitHub tag](https://img.shields.io/github/tag/suzuki-shunsuke/ansible-docker-ce-centos.svg)](https://github.com/suzuki-shunsuke/ansible-docker-ce-centos/releases)
+[![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/suzuki-shunsuke/ansible-docker-ce-centos/master/LICENSE)
+
 ansible role to install Docker CE on CentOS
 
 https://galaxy.ansible.com/suzuki-shunsuke/docker-ce-centos/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@ galaxy_info:
   author: Suzuki Shunsuke
   description: Install Docker CE on CentOS
   license: MIT
-  min_ansible_version: 1.2
+  min_ansible_version: 2.4
   github_branch: master
 
   platforms:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   register: result
   changed_when: no
   failed_when: no
-- include: install_docker.yml
+- import_tasks: install_docker.yml
   when: result.rc
   static: no
 - name: change the status of the docker daemon

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/centos-7.3"
+  config.vm.box = "bento/centos-7.5"
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "2048"
   end


### PR DESCRIPTION
replace `include` into `import_tasks`

BREAKING_CHANGE: ansible version must be >= 2.4 .